### PR TITLE
Update meson usage for static windows builds and accomodate linux

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,15 +39,9 @@ jobs:
             mingw-w64-ucrt-x86_64-libdovi
             mingw-w64-ucrt-x86_64-lcms2
             mingw-w64-ucrt-x86_64-shaderc
-      - name: Build libplacebo
-        working-directory: ./libplacebo
-        run: |
-          meson setup build --buildtype release --default-library=static -Ddemos=false -Dprefix=$PWD/install
-          meson compile -vC build
-          meson install -C build
       - name: Build vs-placebo
         run: |
-          meson setup build --buildtype release
+          meson setup build --buildtype release --prefer-static --default-library=static -Dcpp_link_args='-static' -Dlibplacebo:demos=false -Dlibplacebo:glslang=enabled
           meson compile -vC build
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v1.1.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,6 @@
 	path = libp2p
 	url = https://bitbucket.org/the-sekrit-twc/libp2p.git
 [submodule "libplacebo"]
-	path = libplacebo
+	path = subprojects/libplacebo
 	url = https://github.com/haasn/libplacebo.git
 	ignore = untracked

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,15 @@ project('vs-placebo', ['c', 'cpp'],
 
 win32 = host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
 
+if win32
+  # Use static versions of these libraries
+  shaderc_combined = dependency('shaderc_combined')
+  meson.override_dependency('shaderc', shaderc_combined)
+  spirv_cross_c = dependency('spirv-cross-c')
+  meson.override_dependency('spirv-cross-c-shared', spirv_cross_c)
+endif
+
+placebo = dependency('libplacebo', required: true, version: '>=5.229.0', static: win32)
 vapoursynth_dep = dependency('vapoursynth', static: win32).partial_dependency(includes: true, compile_args: true)
 dovi = dependency('dovi', required: false, static: win32)
 
@@ -26,39 +35,9 @@ sources = []
 subdir('src')
 
 shared_module('vs_placebo', sources,
-  dependencies: [vapoursynth_dep, dovi],
+  dependencies: [placebo, vapoursynth_dep, dovi],
   link_with: [p2p],
   name_prefix: 'lib',
-  include_directories: [
-    'libplacebo/install/include'
-  ],
-  c_args: [
-    # If this isn't defined then libplacebo headers get preprocessed for dynamic linking
-    '-DPL_STATIC'
-  ],
-  link_args: [
-    '-static',
-    # It's hard to get static links to libplacebo cleanly so just dumping link args here
-    meson.current_source_dir() / 'libplacebo/install/lib/libplacebo.a',
-    '-lm',
-    '-pthread',
-    '-lversion',
-    '-lvulkan-1.dll',
-    '-llcms2',
-    '-llcms2_fast_float',
-    '-lshlwapi',
-    '-lMachineIndependent',
-    '-lOSDependent',
-    '-lGenericCodeGen',
-    '-lglslang',
-    '-lSPIRV',
-    '-lSPIRV-Tools-opt',
-    '-lSPIRV-Tools',
-    '-lSPIRV-Tools-link',
-    '-lspirv-cross-glsl',
-    '-lshaderc_combined',
-    '-lspirv-cross-c'
-  ],
   install_dir : join_paths(vapoursynth_dep.get_variable(pkgconfig: 'libdir'), 'vapoursynth'),
   install: true
 )


### PR DESCRIPTION
If we use libplacebo as a subproject and set our meson options very carefully then we can mostly let meson generate the link arguments for us. The notable issue is that libplacebo will try to link shaderc and spirv-cross-c-shared when we want shaderc_combined and spirv-cross-c. This can be addressed by overriding the options. Note that this needs glslang enabled as a dependency to get everything linked statically.

With this structure system libplacebo and dynamic linking should be fully supported for linux users who want to do that.