### PR TITLE
Simplify `filter` function mapping in Resample

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ placebo.Resample(
 
 Input needs to be 8 or 16 bit Integer or 32 bit Float.
 
-- `filter`: See [the header](https://github.com/haasn/libplacebo/blob/6aa96c72fc0e04cf7da64c6022939b7e2d031cae/src/include/libplacebo/filters.h#L271) for possible values (remove the “pl_filter” before the filter name, e.g. `filter="lanczos"`).
+- `filter`: See [the header](https://github.com/haasn/libplacebo/blob/v7.349.0/src/include/libplacebo/filters.h#L268-L299) for possible values (remove the "pl_filter_" before the filter name, e.g. `filter="lanczos"`).
 - `radius`: Override the filter kernel radius. Has no effect if the filter
   kernel is not resizeable.
 - `clamp`: Represents an extra weighting/clamping coefficient for negative

--- a/src/resample.c
+++ b/src/resample.c
@@ -497,31 +497,15 @@ void VS_CC VSPlaceboResampleCreate(const VSMap *in, VSMap *out, void *useResampl
     sampleFilterParams->antiring = vsapi->mapGetFloat(in, "antiring", 0, &err);
 
     const char *filter = vsapi->mapGetData(in, "filter", 0, &err);
+    if (err) {
+        vsapi->logMessage(mtWarning, "Unspecified filter... selecting ewa_lanczos.\n", core);
+        filter = "ewa_lanczos";
+    }
 
-    if (!filter) filter = "ewa_lanczos";
-#define FILTER_ELIF(name) else if (strcmp(filter, #name) == 0) sampleFilterParams->filter = pl_filter_##name;
-    if (strcmp(filter, "spline16") == 0)
-        sampleFilterParams->filter = pl_filter_spline16;
-    FILTER_ELIF(spline36)
-    FILTER_ELIF(spline64)
-    FILTER_ELIF(box)
-    FILTER_ELIF(triangle)
-    FILTER_ELIF(gaussian)
-    FILTER_ELIF(sinc)
-    FILTER_ELIF(lanczos)
-    FILTER_ELIF(ginseng)
-    FILTER_ELIF(ewa_jinc)
-    FILTER_ELIF(ewa_ginseng)
-    FILTER_ELIF(ewa_hann)
-    FILTER_ELIF(bicubic)
-    FILTER_ELIF(catmull_rom)
-    FILTER_ELIF(mitchell)
-    FILTER_ELIF(robidoux)
-    FILTER_ELIF(robidouxsharp)
-    FILTER_ELIF(ewa_robidoux)
-    FILTER_ELIF(ewa_lanczos)
-    FILTER_ELIF(ewa_robidouxsharp)
-    else {
+    const struct pl_filter_config *filter_config = pl_find_filter_config(filter, PL_FILTER_SCALING);
+    if (filter_config) {
+        sampleFilterParams->filter = *filter_config;
+    } else {
         vsapi->logMessage(mtWarning, "Unknown filter... selecting ewa_lanczos.\n", core);
         sampleFilterParams->filter = pl_filter_ewa_lanczos;
     }


### PR DESCRIPTION
It now uses `pl_find_filter_config` to find the filter config instead of requiring that each filter have its own `else if` branch.