### PR TITLE
Share a Vulkan device among filter instances

### DIFF
--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -10,6 +10,8 @@
 #include "resample.h"
 #include "shader.h"
 
+static struct vspl_global global = {0};
+
 void *VSPlaceboInit(enum pl_log_level log_level) {
     struct priv *p = calloc(1, sizeof(struct priv));
     if (!p)
@@ -25,16 +27,21 @@ void *VSPlaceboInit(enum pl_log_level log_level) {
         goto error;
     }
 
-    struct pl_vulkan_params vp = pl_vulkan_default_params;
-    struct pl_vk_inst_params ip = pl_vk_inst_default_params;
-//    ip.debug = true;
-    vp.instance_params = &ip;
-    p->vk = pl_vulkan_create(p->log, &vp);
-
-    if (!p->vk) {
-        fprintf(stderr, "Failed creating vulkan context\n");
-        goto error;
+    if (!global.vk) {
+        struct pl_vulkan_params vp = pl_vulkan_default_params;
+        struct pl_vk_inst_params ip = pl_vk_inst_default_params;
+        // ip.debug = true;
+        vp.instance_params = &ip;
+        global.vk = pl_vulkan_create(p->log, &vp);
+        if (!global.vk) {
+            fprintf(stderr, "Failed creating vulkan context\n");
+            goto error;
+        }
+        atomic_store(&global.ref_count, 0);
     }
+
+    p->vk = global.vk;
+    atomic_fetch_add(&global.ref_count, 1);
 
     // Give this a shorter name for convenience
     p->gpu = p->vk->gpu;
@@ -69,10 +76,13 @@ void VSPlaceboUninit(void *priv)
     pl_renderer_destroy(&p->rr);
     pl_shader_obj_destroy(&p->dither_state);
     pl_dispatch_destroy(&p->dp);
-    pl_vulkan_destroy(&p->vk);
     pl_log_destroy(&p->log);
 
     free(p);
+
+    if (atomic_fetch_sub(&global.ref_count, 1) == 1) {
+        pl_vulkan_destroy(&global.vk);
+    }
 }
 
 VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {

--- a/src/vs-placebo.h
+++ b/src/vs-placebo.h
@@ -1,6 +1,8 @@
 #ifndef VS_PLACEBO_LIBRARY_H
 #define VS_PLACEBO_LIBRARY_H
 
+#include <stdatomic.h>
+
 #include <libplacebo/dispatch.h>
 #include <libplacebo/shaders/sampling.h>
 #include <libplacebo/utils/upload.h>
@@ -26,6 +28,11 @@ struct image {
     int width, height;
     int num_planes;
     struct plane planes[MAX_PLANES];
+};
+
+struct vspl_global {
+    pl_vulkan vk;
+    atomic_int ref_count;
 };
 
 struct priv {


### PR DESCRIPTION
Creating a new Vulkan device per filter instance is mostly fine until the count exceeds around 5-15 instances. At that point things will often silently crash or throw `VK_ERROR_INITIALIZATION_FAILED`. To fix this, there is now a single Vulkan device that is shared among all filter instances.

Tested against 20 Debands over 4000 frames.