### PR TITLE
Revert "Share a Vulkan device among filter instances"

### DIFF
--- a/src/vs-placebo.c
+++ b/src/vs-placebo.c
@@ -10,8 +10,6 @@
 #include "resample.h"
 #include "shader.h"
 
-static struct vspl_global global = {0};
-
 void *VSPlaceboInit(enum pl_log_level log_level) {
     struct priv *p = calloc(1, sizeof(struct priv));
     if (!p)
@@ -27,21 +25,16 @@ void *VSPlaceboInit(enum pl_log_level log_level) {
         goto error;
     }
 
-    if (!global.vk) {
-        struct pl_vulkan_params vp = pl_vulkan_default_params;
-        struct pl_vk_inst_params ip = pl_vk_inst_default_params;
-        // ip.debug = true;
-        vp.instance_params = &ip;
-        global.vk = pl_vulkan_create(p->log, &vp);
-        if (!global.vk) {
-            fprintf(stderr, "Failed creating vulkan context\n");
-            goto error;
-        }
-        atomic_store(&global.ref_count, 0);
-    }
+    struct pl_vulkan_params vp = pl_vulkan_default_params;
+    struct pl_vk_inst_params ip = pl_vk_inst_default_params;
+//    ip.debug = true;
+    vp.instance_params = &ip;
+    p->vk = pl_vulkan_create(p->log, &vp);
 
-    p->vk = global.vk;
-    atomic_fetch_add(&global.ref_count, 1);
+    if (!p->vk) {
+        fprintf(stderr, "Failed creating vulkan context\n");
+        goto error;
+    }
 
     // Give this a shorter name for convenience
     p->gpu = p->vk->gpu;
@@ -76,13 +69,10 @@ void VSPlaceboUninit(void *priv)
     pl_renderer_destroy(&p->rr);
     pl_shader_obj_destroy(&p->dither_state);
     pl_dispatch_destroy(&p->dp);
+    pl_vulkan_destroy(&p->vk);
     pl_log_destroy(&p->log);
 
     free(p);
-
-    if (atomic_fetch_sub(&global.ref_count, 1) == 1) {
-        pl_vulkan_destroy(&global.vk);
-    }
 }
 
 VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin *plugin, const VSPLUGINAPI *vspapi) {

--- a/src/vs-placebo.h
+++ b/src/vs-placebo.h
@@ -1,8 +1,6 @@
 #ifndef VS_PLACEBO_LIBRARY_H
 #define VS_PLACEBO_LIBRARY_H
 
-#include <stdatomic.h>
-
 #include <libplacebo/dispatch.h>
 #include <libplacebo/shaders/sampling.h>
 #include <libplacebo/utils/upload.h>
@@ -28,11 +26,6 @@ struct image {
     int width, height;
     int num_planes;
     struct plane planes[MAX_PLANES];
-};
-
-struct vspl_global {
-    pl_vulkan vk;
-    atomic_int ref_count;
 };
 
 struct priv {


### PR DESCRIPTION
This reverts commit 8b5eb5ae9ad42bae5a6cea53e43dd87bd17b9758.

Unfortunately this led to multiple users getting a different error, `VK_ERROR_DEVICE_LOST`, during encodes and corrupting the output. I have been unable to reproduce it outside of an encode, and I'd rather not have to run an encode to repro because waiting over an hour to test potential fixes sounds like an awful experience. Reverting for now in the interest of stability; v3.2.1 and v3.2.2 will remain available with the `VK_ERROR_INITIALIZATION_FAILED` fix for those that need it and are willing to accept the risk.