### PR TITLE
fix build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 build/
+.vscode/settings.json
+.cache/*
+.DS_Store

--- a/src/shader.c
+++ b/src/shader.c
@@ -189,7 +189,7 @@ static const VSFrame *VS_CC VSPlaceboShaderGetFrame(int n, int activationReason,
                 d->range = r ? PL_COLOR_LEVELS_TV : PL_COLOR_LEVELS_PC;
         }
 
-        const VSVideoFormat dstfmt = d->vi_out.format;
+        VSVideoFormat dstfmt = d->vi_out.format;
         vsapi->queryVideoFormat(&dstfmt, dstfmt.colorFamily, dstfmt.sampleType, dstfmt.bitsPerSample, 0, 0, core);
 
         VSFrame *dst = vsapi->newVideoFrame(&dstfmt, d->width, d->height, frame, core);


### PR DESCRIPTION
clang 19.1.7: 
```
../src/shader.c:193:33: error: passing 'const VSVideoFormat *' (aka 'const struct VSVideoFormat *') to parameter of type 'VSVideoFormat *' (aka 'struct VSVideoFormat *') discards qualifiers [-Werror,-Wincompatible-pointer-types-discards-qualifiers]
  193 |         vsapi->queryVideoFormat(&dstfmt, dstfmt.colorFamily, dstfmt.sampleType, dstfmt.bitsPerSample, 0, 0, core);
      |                                 ^~~~~~~
1 error generated.
```

This PR fixes the issue by defining `dstfmt `without const.